### PR TITLE
FIx: Active should be a property

### DIFF
--- a/lib/components/block-ui-content/block-ui-content.component.ts
+++ b/lib/components/block-ui-content/block-ui-content.component.ts
@@ -23,8 +23,9 @@ export class BlockUIContentComponent implements OnInit, OnDestroy {
   @Input() name: string = BlockUIDefaultName;
   @Input('message') defaultMessage: string;
 
+  active: boolean = false;
+
   private message: string;
-  private active: boolean = false;
   private blockUISubscription: Subscription;
 
   constructor(


### PR DESCRIPTION
Since active is used in the Viewcomponent it should be a property.  Should fix a problem that occurs when performing a production build with Angular CLI (AOT).  