### PR TITLE
fix(component): fix blocking delays and multiple http calls (#45)

### DIFF
--- a/lib/components/block-ui-content/block-ui-content.component.ts
+++ b/lib/components/block-ui-content/block-ui-content.component.ts
@@ -114,7 +114,7 @@ export class BlockUIContentComponent implements OnInit, AfterViewInit, AfterView
 
   private onStart({ name, message }: BlockUIEvent) {
     if (name === this.name) {
-      const delay = this.delayStart || this.settings['delayStart'] || 0;
+      const delay = this.delayStart || this.settings.delayStart || 0;
 
       if (delay) {
         if (this.state.startTimeout == null) {
@@ -137,7 +137,7 @@ export class BlockUIContentComponent implements OnInit, AfterViewInit, AfterView
         if (!this.active) {
           this.clearState();
         } else {
-          const delay = this.delayStop || this.settings['delayStop'] || 0;
+          const delay = this.delayStop || this.settings.delayStop || 0;
           if (delay) {
             if (this.state.stopTimeout == null) {
               this.state.stopTimeout = setTimeout(() => {
@@ -179,8 +179,8 @@ export class BlockUIContentComponent implements OnInit, AfterViewInit, AfterView
   }
 
   private clearState() {
-    this.state.startTimeout && clearTimeout(this.state.startTimeout);
-    this.state.stopTimeout && clearTimeout(this.state.stopTimeout);
+    this.state.startTimeout != null && clearTimeout(this.state.startTimeout);
+    this.state.stopTimeout != null && clearTimeout(this.state.stopTimeout);
     this.state.blockCount = 0;
     this.state.startTimeout = null;
     this.state.stopTimeout = null;


### PR DESCRIPTION
Updating the logic for starting / stopping the blocker so that the state of blocking is saved, then whenever a start, stop or reset event is received, it checks whether other blocked calls are already in progress and processes the call accordingly.

This should allow multiple concurrent calls to be handled, only showing the blocker at the start of the first call and not hiding it until the end of the final call.

Also, if a delayStart and delayStop value is set, the delay will only be used for hiding the blocker if the blocker is already active when the stop event is raised rather than processing the entire stop event after the delay, regardless of the current state of the blocker. This should stop the issue where the blocker can flicker on and off after a short http call, no matter what.