### PR TITLE
feat(core): queue multiple blocking calls (#43)

### DIFF
--- a/lib/components/block-ui-content/block-ui-content.component.spec.ts
+++ b/lib/components/block-ui-content/block-ui-content.component.spec.ts
@@ -43,6 +43,8 @@ describe('block-ui-content component', () => {
 
       testCmp = cf.debugElement.componentInstance;
       blkContComp = cf.debugElement.query(By.directive(BlockUIContentComponent));
+
+      testCmp.blockUI.reset();
     });
 
     it('block-ui-wrapper is not active by default', () => {
@@ -162,6 +164,8 @@ describe('block-ui-content component', () => {
 
       testCmp = cf.debugElement.componentInstance;
       blkContComp = cf.debugElement.query(By.directive(BlockUIContentComponent));
+
+      testCmp.blockUI.reset();
     });
 
     it('appends template to blockUIContent', () => {
@@ -242,6 +246,7 @@ describe('block-ui-content component', () => {
 
       testCmp = cf.debugElement.componentInstance;
       blkContComp = cf.debugElement.query(By.directive(BlockUIContentComponent));
+      testCmp.blockUI.reset();
     });
 
     it('appends template to blockUIContent', () => {
@@ -295,6 +300,7 @@ describe('block-ui-content component', () => {
 
       testCmp = cf.debugElement.componentInstance;
       blkContComp = cf.debugElement.query(By.directive(BlockUIContentComponent));
+      testCmp.blockUI.reset();
     });
 
     it('displays module default message on start', () => {

--- a/lib/components/block-ui-content/block-ui-content.component.ts
+++ b/lib/components/block-ui-content/block-ui-content.component.ts
@@ -60,15 +60,17 @@ export class BlockUIContentComponent implements OnInit, AfterViewInit, AfterView
 
   ngAfterViewInit() {
     try {
-      if (this.templateCmp) {
-        if (this.templateCmp instanceof TemplateRef) {
-          this.templateOutlet.createEmbeddedView(this.templateCmp);
-        } else {
-            const templateComp = this.resolver.resolveComponentFactory(this.templateCmp);
-            this.templateCompRef = this.templateOutlet.createComponent(templateComp);
+      if (!this.templateCmp) {
+        return false;
+      }
 
-            this.updateBlockTemplate(this.message);
-        }
+      if (this.templateCmp instanceof TemplateRef) {
+        this.templateOutlet.createEmbeddedView(this.templateCmp);
+      } else {
+        const templateComp = this.resolver.resolveComponentFactory(this.templateCmp);
+        this.templateCompRef = this.templateOutlet.createComponent(templateComp);
+
+        this.updateBlockTemplate(this.message);
       }
     } catch (error) {
       console.error('ng-block-ui:', error);
@@ -114,7 +116,7 @@ export class BlockUIContentComponent implements OnInit, AfterViewInit, AfterView
       const delay = this.delayStart || this.settings.delayStart || 0;
 
       if (delay) {
-        if (this.state.startTimeout == null) {
+        if (this.state.startTimeout === null) {
           this.state.startTimeout = setTimeout(() => {
             this.showBlock(message);
           }, delay);
@@ -123,6 +125,8 @@ export class BlockUIContentComponent implements OnInit, AfterViewInit, AfterView
       } else {
         this.showBlock(message);
       }
+
+      this.updateInstanceBlockCount();
     }
   }
 
@@ -136,7 +140,7 @@ export class BlockUIContentComponent implements OnInit, AfterViewInit, AfterView
         } else {
           const delay = this.delayStop || this.settings.delayStop || 0;
           if (delay) {
-            if (this.state.stopTimeout == null) {
+            if (this.state.stopTimeout === null) {
               this.state.stopTimeout = setTimeout(() => {
                 this.hideBlock();
               }, delay);
@@ -146,6 +150,8 @@ export class BlockUIContentComponent implements OnInit, AfterViewInit, AfterView
           }
         }
       }
+
+      this.updateInstanceBlockCount();
     }
   }
 
@@ -181,9 +187,10 @@ export class BlockUIContentComponent implements OnInit, AfterViewInit, AfterView
     this.state.blockCount = 0;
     this.state.startTimeout = null;
     this.state.stopTimeout = null;
+    this.updateInstanceBlockCount();
   }
 
-  private updateBlockTemplate(msg: string): void {
+  private updateBlockTemplate(msg: any): void {
     if (this.templateCompRef && this.templateCompRef instanceof ComponentRef) {
       this.templateCompRef.instance.message = msg;
     }
@@ -192,6 +199,12 @@ export class BlockUIContentComponent implements OnInit, AfterViewInit, AfterView
   private onUnsubscribe(name: string) {
     if (this.blockUISubscription && name === this.name) {
       this.blockUISubscription.unsubscribe();
+    }
+  }
+
+  private updateInstanceBlockCount() {
+    if (this.blockUI.blockUIInstances[name]) {
+      this.blockUI.blockUIInstances[name].blockCount = this.state.blockCount;
     }
   }
 

--- a/lib/models/block-ui.model.ts
+++ b/lib/models/block-ui.model.ts
@@ -15,6 +15,11 @@ export interface NgBlockUI {
     isActive: boolean;
 
     /**
+     * Number of start method calls for instance
+     */
+    blockCount: number;
+
+    /**
      * Starts blocking for BlockUI instance
      */
     start(message?: any): void;

--- a/lib/services/block-ui-instance.service.ts
+++ b/lib/services/block-ui-instance.service.ts
@@ -11,7 +11,7 @@ import { BlockUIService } from '../../index';
 @Injectable()
 export class BlockUIInstanceService {
   blockUISettings: BlockUISettings | any = {};
-  blockUIInstances: NgBlockUI[] = [];
+  blockUIInstances: any = {};
   private blockUISubject: ReplaySubject<any> = new ReplaySubject();
   private blockUIObservable: Observable<any> = this.blockUISubject.asObservable();
 
@@ -31,6 +31,7 @@ export class BlockUIInstanceService {
     const blockUI = {
       name,
       isActive: false,
+      blockCount: 0,
       start: this.dispatch(this.blockUISubject, BlockUIActions.START, name),
       update: this.dispatch(this.blockUISubject, BlockUIActions.UPDATE, name),
       stop: this.dispatch(this.blockUISubject, BlockUIActions.STOP, name),
@@ -38,7 +39,7 @@ export class BlockUIInstanceService {
       unsubscribe: this.dispatch(this.blockUISubject, BlockUIActions.UNSUBSCRIBE, name)
     } as NgBlockUI;
 
-    this.blockUIInstances.push(blockUI);
+    this.blockUIInstances[name] = this.blockUIInstances[name] || blockUI;
 
     return blockUI;
   }
@@ -62,9 +63,7 @@ export class BlockUIInstanceService {
     }
 
     if (isActive !== null) {
-      this.blockUIInstances.forEach((i: any) =>
-        i.isActive = i.name === name ? isActive : i.isActive
-      );
+      this.blockUIInstances[name].isActive = isActive;
     }
   }
 

--- a/lib/services/block-ui.service.ts
+++ b/lib/services/block-ui.service.ts
@@ -39,11 +39,12 @@ export class BlockUIService {
     const targets = target ? this.toArray(target) : null;
     const instances = this.blockUIInstance.blockUIInstances;
 
-    return instances.some((i: any) => {
+    return Object.keys(instances).some((key: string) => {
       if (!targets) {
-        return i.isActive;
+        return instances[key].isActive;
       }
-      return targets.indexOf(i.name) >= 0 && i.isActive;
+
+      return targets.indexOf(instances[key].name) >= 0 && instances[key].isActive;
     });
   }
 


### PR DESCRIPTION
## Summary
Adds queueing to all all blocking calls so that the number of calls to `start` and `stop` are tracked.

### Current Behavior:
In the example below blocking would be stopped even though the same instance has had `start` called multiple times. The issue with this is that if the user wants to start blocking from multiple services and does not want the blocking to stop when one of the services resolve they would have to keep track of all services and then call stop when everything resolves. Calling multiple services can happen frequently in apps so the burden of accounting for this shouldn’t be on the user of the library.

#### Example
```
this.blockUI.start()
this.blockUI.start()
this.blockUI.stop()
```

### New Behavior: 
Calls are now queued so the previous example would result in blocking still being shown until `stop` has been called a second time.  To clear the call queue when there are multiple blocking calls, the `reset ` method could still be called to achieve the same behavior as before.

#### Example
```
this.blockUI.start()
this.blockUI.start()
this.blockUI.reset()
```
