### PR TITLE
fix parameter ordering in README following the addition of 'blockAllRequestsInProgress' parameter.

### DIFF
--- a/docs/http-module.md
+++ b/docs/http-module.md
@@ -30,16 +30,6 @@ Accepts an array of requests to be filtered out from from being blocked.
 requestFilters: (RegExp | { method: string, url: RegExp } | Function)[]
 ```
 
-### Setting: `blockAllRequestsInProgress`
-Accepts a boolean. If set to `true`, it deactivates the BlockUI only once the last httpRequest has been processed in case of parallel requests.
-
-Defaulted to `false`.
-
-**Types**
-```
-blockAllRequestsInProgress: boolean
-```
-
 _Note: If using RegExp with AOT compiling, please see this [Stack Overflow Post](https://stackoverflow.com/questions/48751006/ng-build-gives-an-error-because-of-regexp)._
 
 #### Type: `RegExp`
@@ -102,3 +92,10 @@ function filterFooBar(req HttpRequest<any>): boolean {
 })
 export class AppModule {}
 ```
+
+### Setting: `blockAllRequestsInProgress`
+Accepts a boolean. If set to `true`, it deactivates the BlockUI only once the last httpRequest has been processed in case of parallel requests.
+
+Defaulted to `false`.
+
+#### Type: `boolean`


### PR DESCRIPTION
Sorry for missing with your master branch @kuuurt13.
I just realized the README wasn't correct once browsing github after the merge.