### PR TITLE
fix(http): Restore "blockAllRequestsInProgress" setting (#96)

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,7 @@ Instead of declaring seperate instances with the `@BlockUI()` decorator you can 
 | `isActive`    | <code>target: string &#124; string[]</code>                | Indicates if the targeted instance(s) is blocking.                                       |
 | `start`       | <code>target: string &#124; string[], message?: any</code> | Starts blocking for a single instance or multiple instances by passing instance name(s). |
 | `stop`        | <code>target: string &#124; string[]</code>                | Stops blocking for a single instance or multiple instances by passing instance name(s).  |
+| `reset`       | <code>target: string &#124; string[]</code>                | Resets blocking for a single instance or multiple instances by passing instance name(s). |
 | `unsubscribe` | <code>target: string &#124; string[]</code>                | Unsubscribes a single instance or multiple instances by passing instance name(s).        |
 
 ## Other Modules

--- a/dev/app/app.module.ts
+++ b/dev/app/app.module.ts
@@ -12,11 +12,13 @@ import { BlockTemplateComponent } from './block-template/block-template.componen
 import { AppComponent } from './app.component';
 import { DeafultComponent } from './default/default.component';
 import { LandingPageComponent } from './landing-page/landing-page.component';
+import { MultiHttpComponent } from './multi-http/multi-http.component';
 
 const appRoutes: Routes = [
   { path: '', canActivateChild: [BlockUIPreventNavigation], children: [
     { path: '', component: DeafultComponent },
-    { path: 'landing-page', component: LandingPageComponent }
+    { path: 'landing-page', component: LandingPageComponent },
+    { path: 'multi-http', component: MultiHttpComponent }
   ]}
 ];
 
@@ -26,12 +28,12 @@ const appRoutes: Routes = [
     BlockElementModule,
     BlockUIModule.forRoot({
       message: 'Global Default Message',
-      delayStart: 500,
       template: BlockTemplateComponent
     }),
     BlockUIRouterModule.forRoot(),
     BlockUIHttpModule.forRoot({
-      requestFilters: [] // /\/api.github.com\/users\//
+      requestFilters: [], // /\/api.github.com\/users\//
+      blockAllRequestsInProgress: true
     }),
     HttpClientModule,
     RouterModule.forRoot(appRoutes)
@@ -40,7 +42,8 @@ const appRoutes: Routes = [
     BlockTemplateComponent,
     AppComponent,
     DeafultComponent,
-    LandingPageComponent
+    LandingPageComponent,
+    MultiHttpComponent
   ],
   providers: [],
   entryComponents: [

--- a/dev/app/default/default.component.html
+++ b/dev/app/default/default.component.html
@@ -9,8 +9,11 @@
   <button class="button button--default" (click)="blockAllElements()">Block All Elements</button>
 </div>
 <div class="controls">
-    <button class="button button--default" routerLink="/landing-page" >Change Route</button>
-  </div>
+  <button class="button button--default" routerLink="/landing-page">Change Route</button>
+</div>
+<div class="controls">
+  <button class="button button--default" routerLink="/multi-http">Multi Http Test</button>
+</div>
 <div *ngFor="let block of blockInstances">
   <block-element *blockUI="block; message: 'Default...'"></block-element>
 </div>

--- a/dev/app/multi-http/multi-http.component.html
+++ b/dev/app/multi-http/multi-http.component.html
@@ -1,0 +1,8 @@
+<div>
+    <div style="text-align:center">
+      <h1>Request 1: {{requests.first}}</h1>
+      <h1>Request 2: {{requests.second}}</h1>
+
+      <button  class="button button--default" (click)="makeReqs()">Make Request</button>
+    </div>
+</div>

--- a/dev/app/multi-http/multi-http.component.ts
+++ b/dev/app/multi-http/multi-http.component.ts
@@ -1,0 +1,30 @@
+import { Component } from "@angular/core";
+import { HttpClient } from "@angular/common/http";
+
+@Component({
+  selector: "multi-http",
+  templateUrl: "./multi-http.component.html",
+  styleUrls: [],
+  moduleId: __moduleName
+})
+export class MultiHttpComponent {
+  requests = {
+    first: "undefined",
+    second: "undefined"
+  };
+  url = "https://httpstat.us/200?sleep=";
+
+  constructor(public http: HttpClient) {}
+
+  getWithTimeout(request: string, timeout: number) {
+    this.requests[request] = "pending";
+    this.http.get(this.url + timeout).subscribe(data => {
+      this.requests[request] = "complete";
+    });
+  }
+
+  makeReqs() {
+    this.getWithTimeout("first", 1000);
+    this.getWithTimeout("second", 3000);
+  }
+}

--- a/http/block-ui-http.interceptor.ts
+++ b/http/block-ui-http.interceptor.ts
@@ -35,16 +35,19 @@ export class BlockUIInterceptor implements HttpInterceptor {
         finalize(() => {
           if (this.shouldBlock(request)) {
             this.activeHttpRequests--;
-
+            const { blockAllRequestsInProgress } = this.blockUIHttpSettings.settings;
             let stopBlockUI: boolean = false;
-            if (!!this.blockUIHttpSettings.settings.blockAllRequestsInProgress && this.activeHttpRequests <= 0) {
+
+            if (!!blockAllRequestsInProgress && this.activeHttpRequests <= 0) {
               this.activeHttpRequests = 0;
               stopBlockUI = true;
             } else if (active) {
               stopBlockUI = true;
             }
+
             if (stopBlockUI) {
-              this.blockUIService.stop(BLOCKUI_DEFAULT);
+              const method: string = blockAllRequestsInProgress ? 'stop' : 'reset';
+              this.blockUIService[method](BLOCKUI_DEFAULT);
             }
           }
         })
@@ -53,7 +56,7 @@ export class BlockUIInterceptor implements HttpInterceptor {
 
   shouldBlock(request: HttpRequest<any>): boolean {
     const { method, urlWithParams } = request;
-    const settings = this.blockUIHttpSettings.settings;
+    const { settings } = this.blockUIHttpSettings;
     const requestFilters = settings.requestFilters || [];
 
     return !requestFilters.some((f: any) => {

--- a/lib/services/block-ui.service.ts
+++ b/lib/services/block-ui.service.ts
@@ -26,6 +26,13 @@ export class BlockUIService {
   }
 
   /**
+  * Reset blocking for given BlockUI instance or instances
+  */
+  reset(target: string | string[]): void {
+    this.dispatch(target, BlockUIActions.RESET);
+  }
+
+  /**
   * Unsubscribes for given BlockUI instance or instances
   */
   unsubscribe(target: string | string[]): void {


### PR DESCRIPTION
Fixes issue with the `blockAllRequestsInProgress: false` setting not being honored (which is the default) that was introduced in 4820007cd1c8a5aa8e8cdb46c55710c7544dc6f2. Fixing for now since it was introduced with patch but planning on changing this behavior in next major release.